### PR TITLE
Gestione pannello

### DIFF
--- a/src/batteri/mainForm.form
+++ b/src/batteri/mainForm.form
@@ -4,7 +4,12 @@
   <Properties>
     <Property name="defaultCloseOperation" type="int" value="3"/>
     <Property name="title" type="java.lang.String" value="Bacteria"/>
-    <Property name="resizable" type="boolean" value="false"/>
+    <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+      <Dimension value="[1324, 700]"/>
+    </Property>
+    <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+      <Dimension value="[1324, 70]"/>
+    </Property>
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
@@ -35,6 +40,9 @@
         <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[150, 100]"/>
         </Property>
+        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[300, 70]"/>
+        </Property>
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
@@ -50,6 +58,12 @@
       <Properties>
         <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
           <Color blue="ff" green="ff" red="ff" type="rgb"/>
+        </Property>
+        <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[1324, 700]"/>
+        </Property>
+        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[1024, 700]"/>
         </Property>
       </Properties>
       <Constraints>

--- a/src/batteri/mainForm.form
+++ b/src/batteri/mainForm.form
@@ -4,12 +4,10 @@
   <Properties>
     <Property name="defaultCloseOperation" type="int" value="3"/>
     <Property name="title" type="java.lang.String" value="Bacteria"/>
-    <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[1324, 700]"/>
-    </Property>
     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[1324, 70]"/>
+      <Dimension value="[0, 0]"/>
     </Property>
+    <Property name="resizable" type="boolean" value="false"/>
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>

--- a/src/batteri/mainForm.java
+++ b/src/batteri/mainForm.java
@@ -80,6 +80,8 @@ public class mainForm extends javax.swing.JFrame {
         );
         this.jPanelResult.add(btnStop);
         pack();
+        this.setSize(food.getWidth()+ LARGHEZZA_PANNELLO_LATERALE, 
+                    food.getHeight()+ ALTEZZA_BORDO);
         //Timer per l'aggiornamento della simulazione
         ActionListener taskUpdateSimulation;
         taskUpdateSimulation = new ActionListener() {
@@ -211,8 +213,8 @@ public class mainForm extends javax.swing.JFrame {
 
         setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
         setTitle("Bacteria");
-        setMinimumSize(new java.awt.Dimension(1324, 700));
-        setPreferredSize(new java.awt.Dimension(1324, 70));
+        setPreferredSize(new java.awt.Dimension(0, 0));
+        setResizable(false);
 
         jPanelResult.setBorder(javax.swing.BorderFactory.createLineBorder(new java.awt.Color(0, 0, 0)));
         jPanelResult.setMinimumSize(new java.awt.Dimension(150, 100));
@@ -296,5 +298,6 @@ public class mainForm extends javax.swing.JFrame {
     private HashMap<String,Integer> numeroBatteri;
     private HashMap<String,Color> coloreBatteri;
     private ArrayList<String> nomiBatteri;
-    
+    static private final int LARGHEZZA_PANNELLO_LATERALE = 300; 
+    static private final int ALTEZZA_BORDO = 30; 
 }

--- a/src/batteri/mainForm.java
+++ b/src/batteri/mainForm.java
@@ -211,14 +211,18 @@ public class mainForm extends javax.swing.JFrame {
 
         setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
         setTitle("Bacteria");
-        setResizable(false);
+        setMinimumSize(new java.awt.Dimension(1324, 700));
+        setPreferredSize(new java.awt.Dimension(1324, 70));
 
         jPanelResult.setBorder(javax.swing.BorderFactory.createLineBorder(new java.awt.Color(0, 0, 0)));
         jPanelResult.setMinimumSize(new java.awt.Dimension(150, 100));
+        jPanelResult.setPreferredSize(new java.awt.Dimension(300, 70));
         jPanelResult.setLayout(new javax.swing.BoxLayout(jPanelResult, javax.swing.BoxLayout.Y_AXIS));
         getContentPane().add(jPanelResult, java.awt.BorderLayout.LINE_END);
 
         jPanelTerrain.setBackground(new java.awt.Color(255, 255, 255));
+        jPanelTerrain.setMinimumSize(new java.awt.Dimension(1324, 700));
+        jPanelTerrain.setPreferredSize(new java.awt.Dimension(1024, 700));
         jPanelTerrain.setLayout(new java.awt.BorderLayout());
         getContentPane().add(jPanelTerrain, java.awt.BorderLayout.CENTER);
 


### PR DESCRIPTION
Ridimensiona il pannello con i nomi in modo da non avere più il ridimensionamento in runtime, allunga un po' l'altezza della finestra perchè una parte del terreno, pur esistendo, non veniva disegnata